### PR TITLE
chore: remove `FileReader` API

### DIFF
--- a/createICS.ts
+++ b/createICS.ts
@@ -1,26 +1,18 @@
 import parseCSV from "./parse";
 import kdb from "./kdb.json";
 
-const createICS = (csv: Blob, ifDeadlinesIncluded: boolean) =>
-  new Promise<string>((resolve) => {
-    const reader = new FileReader();
-    reader.readAsText(csv);
-    reader.onload = () => {
-      const fileContent = String(reader.result);
-      const isFromKdBAlt = fileContent.slice(0, 1) === "科";
-      const idList = isFromKdBAlt
-        ? fileContent
-            .split("\n")
-            .filter((x) => x.slice(0, 1) === '"')
-            .map((x) => x.replace('"', ""))
-            .filter((x, i, self) => self.indexOf(x) === i)
-        : fileContent.split("\n").filter((x, i, self) => self.indexOf(x) === i);
-      const output =
-        parseCSV(idList, kdb, ifDeadlinesIncluded, isFromKdBAlt) +
-        `END:VCALENDAR`;
-
-      resolve(output);
-    };
-  });
+const createICS = (fileContent: string, ifDeadlinesIncluded: boolean) => {
+  const isFromKdBAlt = fileContent.slice(0, 1) === "科";
+  const idList = isFromKdBAlt
+    ? fileContent
+        .split("\n")
+        .filter((x) => x.slice(0, 1) === '"')
+        .map((x) => x.replace('"', ""))
+        .filter((x, i, self) => self.indexOf(x) === i)
+    : fileContent.split("\n").filter((x, i, self) => self.indexOf(x) === i);
+  return (
+    parseCSV(idList, kdb, ifDeadlinesIncluded, isFromKdBAlt) + `END:VCALENDAR`
+  );
+};
 
 export { createICS };


### PR DESCRIPTION
I'll transfer the logic which relates to the `FileReader` API to _twinc_ afterward.