### PR TITLE
parseCSVから最終行の空要素関連処理を削除

### DIFF
--- a/parse.ts
+++ b/parse.ts
@@ -298,13 +298,7 @@ export const parseCSV = (
   const eventEnd = "\nEND:VEVENT\n";
   const courseList: Course[] = [];
   const courseIdList: string[] = [];
-  let idListLength: number;
-
-  if (isFromKdbAlt) {
-    idListLength = idList.length;
-  } else {
-    idListLength = idList.length - 1;
-  }
+  const idListLength = idList.length;
 
   //Search courses
   for (let i = 0; i < idListLength; i++) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -41,7 +41,6 @@ describe("parseCSV", () => {
     "GC41203",
     "GC53401",
     "GC55201",
-    "",
   ];
   const ics = `${parseCSV(idList, kdb, true, false, {})}END:VCALENDAR`;
   it("should return a string", () => {


### PR DESCRIPTION
ローカルで動作確認を行っていたところ、TWINSからエクスポートしたCSVにおいて最終行が無視されるようだったので修正しました
TWINSで仕様変更が行われたのか否かは不明です